### PR TITLE
Unix EOF for Windows enviroment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+"src/*" text=auto eol=lf


### PR DESCRIPTION
Often on Windows code checkout with Windows EOF. But for correct building local container (for example, for testing purposes), all shell scripts copied to container should have Unix EOF.