### PR TITLE
Install and run vscode server as service

### DIFF
--- a/src/entrypoint
+++ b/src/entrypoint
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bash init && code tunnel --accept-server-license-terms --disable-telemetry --name ${MACHINE_NAME}
+bash init && code tunnel service install --accept-server-license-terms --disable-telemetry --name ${MACHINE_NAME}


### PR DESCRIPTION
Authentication required each time docker container starts, which can be a headache if this is a long live container. Looks like running vscode server as a service solves this problem.